### PR TITLE
Wake word

### DIFF
--- a/android/app/src/main/kotlin/dev/agixt/agixt/BackgroundService.kt
+++ b/android/app/src/main/kotlin/dev/agixt/agixt/BackgroundService.kt
@@ -24,7 +24,15 @@ class BackgroundService : Service(), LifecycleDetector.Listener {
     private var flutterEngine: FlutterEngine? = null
     private val flutterLoader = FlutterLoader()
     private var speechRecognizer: SpeechRecognizer? = null
-    private val wakeWord = "agixt"
+    private var wakeWord = "agent" // Default wake word changed to "agent"
+
+    // Method to update the wake word from Flutter
+    fun updateWakeWord(newWakeWord: String) {
+        if (newWakeWord.isNotEmpty()) {
+            Log.i("WakeWord", "Updating wake word from '$wakeWord' to '$newWakeWord'")
+            wakeWord = newWakeWord
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -33,6 +41,14 @@ class BackgroundService : Service(), LifecycleDetector.Listener {
         if (!flutterLoader.initialized()) {
             flutterLoader.startInitialization(applicationContext)
             flutterLoader.ensureInitializationComplete(applicationContext, null)
+        }
+
+        // Load custom wake word from shared preferences if available
+        val prefs = getSharedPreferences("dev.agixt.agixt.WakeWordSettings", Context.MODE_PRIVATE)
+        val savedWakeWord = prefs.getString("wakeWord", null)
+        if (!savedWakeWord.isNullOrEmpty()) {
+            wakeWord = savedWakeWord
+            Log.i("WakeWord", "Loaded custom wake word: $wakeWord")
         }
 
         val notification = Notifications.buildForegroundNotification(this)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -11,6 +11,26 @@ import UIKit
     let controller = window?.rootViewController as? FlutterViewController
     if let controller = controller {
       FlutterBinaryMessengerRelay.shared.setBinaryMessenger(controller.binaryMessenger)
+      
+      // Register method channel for wake word customization
+      let wakeWordChannel = FlutterMethodChannel(name: "dev.agixt.agixt/ios_wake_word", 
+                                               binaryMessenger: controller.binaryMessenger)
+      wakeWordChannel.setMethodCallHandler { (call, result) in
+        if call.method == "updateWakeWord" {
+          if let args = call.arguments as? [String: Any],
+             let wakeWord = args["wakeWord"] as? String {
+            // Update the wake word in SpeechStreamRecognizer
+            SpeechStreamRecognizer.shared.updateWakeWord(wakeWord)
+            result(true)
+          } else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", 
+                              message: "Missing wakeWord parameter", 
+                              details: nil))
+          }
+        } else {
+          result(FlutterMethodNotImplemented)
+        }
+      }
     }
     
     GeneratedPluginRegistrant.register(with: self)

--- a/ios/Runner/SpeechStreamRecognizer.swift
+++ b/ios/Runner/SpeechStreamRecognizer.swift
@@ -37,6 +37,8 @@ class SpeechStreamRecognizer {
     private var lastTranscription: SFTranscription? // cache to make contrast between near results
     private var cacheString = "" // cache stream recognized formattedString
     
+    private let wakeWord = "agixt"
+    
     enum RecognizerError: Error {
         case nilRecognizer
         case notAuthorizedToRecognize
@@ -115,7 +117,9 @@ class SpeechStreamRecognizer {
             if let error = error {
                 print("SpeechRecognizer Recognition error: \(error)")
             } else if let result = result {
-                    
+                let currentTranscription = result.bestTranscription.formattedString
+                self.processTranscription(currentTranscription)
+                
                 let currentTranscription = result.bestTranscription
                 if lastTranscription == nil {
                     cacheString = currentTranscription.formattedString
@@ -185,6 +189,21 @@ class SpeechStreamRecognizer {
                 print("Failed to get pointer to audio data")
             }
         }
+    }
+    
+    func startWakeWordDetection() {
+        startRecognition(identifier: "EN")
+    }
+
+    func processTranscription(_ transcription: String) {
+        if transcription.lowercased().contains(wakeWord) {
+            triggerAGiXTWorkflow(transcription)
+        }
+    }
+
+    private func triggerAGiXTWorkflow(_ transcription: String) {
+        print("Wake word detected: \(transcription)")
+        // Logic to send transcription to AGiXT workflow
     }
 }
 

--- a/ios/Runner/SpeechStreamRecognizer.swift
+++ b/ios/Runner/SpeechStreamRecognizer.swift
@@ -37,7 +37,17 @@ class SpeechStreamRecognizer {
     private var lastTranscription: SFTranscription? // cache to make contrast between near results
     private var cacheString = "" // cache stream recognized formattedString
     
-    private let wakeWord = "agixt"
+    private var wakeWord = "agent" // Changed default wake word to "agent"
+    
+    // Method to update the wake word
+    func updateWakeWord(_ newWakeWord: String) {
+        if !newWakeWord.isEmpty {
+            print("Updating wake word from '\(wakeWord)' to '\(newWakeWord)'")
+            wakeWord = newWakeWord
+            // Save to UserDefaults for persistence
+            UserDefaults.standard.set(newWakeWord, forKey: "AGiXTWakeWord")
+        }
+    }
     
     enum RecognizerError: Error {
         case nilRecognizer
@@ -57,6 +67,13 @@ class SpeechStreamRecognizer {
     
     private init() {
         dateFormatter.dateFormat = "HH:mm:ss.SSS"
+        
+        // Load custom wake word from UserDefaults if available
+        if let savedWakeWord = UserDefaults.standard.string(forKey: "AGiXTWakeWord"), !savedWakeWord.isEmpty {
+            wakeWord = savedWakeWord
+            print("Loaded custom wake word: \(wakeWord)")
+        }
+        
         if #available(iOS 13.0, *) {
             Task {
                 do {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:agixt/models/agixt/daily.dart';
 import 'package:agixt/models/agixt/stop.dart';
 import 'package:agixt/screens/auth/login_screen.dart';
 import 'package:agixt/screens/auth/profile_screen.dart';
+import 'package:agixt/services/ai_service.dart';
 import 'package:agixt/services/bluetooth_manager.dart';
 import 'package:agixt/services/stops_manager.dart';
 import 'package:agixt/utils/ui_perfs.dart';
@@ -19,6 +20,9 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:app_links/app_links.dart';
 import 'screens/home_screen.dart';
+
+// Wake word detection method channel
+const MethodChannel _wakeWordChannel = MethodChannel('dev.agixt.agixt/wake_word');
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
     FlutterLocalNotificationsPlugin();
@@ -37,6 +41,9 @@ void main() async {
     appUri: APP_URI,
     appName: APP_NAME,
   );
+
+  // Set up wake word detection method channel handler
+  _setupWakeWordDetection();
 
   flutterLocalNotificationsPlugin.initialize(
     InitializationSettings(
@@ -355,4 +362,23 @@ void _handleDeleteAction(String actionId) async {
     }
     StopsManager().reload();
   }
+}
+
+void _setupWakeWordDetection() {
+  _wakeWordChannel.setMethodCallHandler((call) async {
+    if (call.method == 'processVoiceCommand') {
+      debugPrint('Wake word detected and voice command received');
+      
+      // Extract the transcription from the method call arguments
+      final Map<dynamic, dynamic> args = call.arguments as Map;
+      final String transcription = args['transcription'] as String;
+      
+      // Process the voice command using AIService
+      if (transcription.isNotEmpty) {
+        debugPrint('Processing voice command: $transcription');
+        await AIService.singleton.processWakeWordCommand(transcription);
+      }
+    }
+    return null;
+  });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,10 +9,12 @@ import 'package:agixt/models/agixt/daily.dart';
 import 'package:agixt/models/agixt/stop.dart';
 import 'package:agixt/screens/auth/login_screen.dart';
 import 'package:agixt/screens/auth/profile_screen.dart';
+import 'package:agixt/screens/wake_word_settings_screen.dart';
 import 'package:agixt/services/ai_service.dart';
 import 'package:agixt/services/bluetooth_manager.dart';
 import 'package:agixt/services/stops_manager.dart';
 import 'package:agixt/utils/ui_perfs.dart';
+import 'package:agixt/utils/wake_word_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_background_service/flutter_background_service.dart';
@@ -67,6 +69,9 @@ void main() async {
 
   await BluetoothManager.singleton.initialize();
   BluetoothManager.singleton.attemptReconnectFromStorage();
+  
+  // Initialize wake word settings
+  await WakeWordSettings.singleton.initialize();
 
   var channel = const MethodChannel('dev.agixt.agixt/background_service');
   var callbackHandle = PluginUtilities.getCallbackHandle(backgroundMain);
@@ -208,6 +213,7 @@ class _AppState extends State<App> {
         '/home': (context) => const HomePage(),
         '/login': (context) => const LoginScreen(),
         '/profile': (context) => const ProfileScreen(),
+        '/wake_word_settings': (context) => const WakeWordSettingsScreen(),
       },
     );
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:agixt/screens/settings/notifications_screen.dart';
 import 'package:agixt/screens/settings/traewelling_screen.dart';
 import 'package:agixt/screens/settings/ui_settings.dart';
 import 'package:agixt/screens/settings/whisper_screen.dart';
+import 'package:agixt/screens/wake_word_settings_screen.dart';
 import 'package:agixt/widgets/about_dialog.dart';
 import 'package:flutter/material.dart';
 
@@ -83,6 +84,23 @@ class SettingsPage extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => WhisperSettingsPage()),
+              );
+            },
+          ),
+          // Add Wake Word Settings option
+          ListTile(
+            title: Row(
+              children: [
+                Icon(Icons.record_voice_over),
+                SizedBox(width: 10),
+                Text('Wake Word Settings'),
+              ],
+            ),
+            trailing: Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const WakeWordSettingsScreen()),
               );
             },
           ),

--- a/lib/screens/wake_word_settings_screen.dart
+++ b/lib/screens/wake_word_settings_screen.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import 'package:agixt/utils/wake_word_settings.dart';
+
+class WakeWordSettingsScreen extends StatefulWidget {
+  const WakeWordSettingsScreen({Key? key}) : super(key: key);
+
+  @override
+  State<WakeWordSettingsScreen> createState() => _WakeWordSettingsScreenState();
+}
+
+class _WakeWordSettingsScreenState extends State<WakeWordSettingsScreen> {
+  final _wakeWordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  final _settings = WakeWordSettings.singleton;
+  bool _isLoading = false;
+  String _currentWakeWord = '';
+  
+  @override
+  void initState() {
+    super.initState();
+    _loadCurrentWakeWord();
+  }
+  
+  @override
+  void dispose() {
+    _wakeWordController.dispose();
+    super.dispose();
+  }
+  
+  Future<void> _loadCurrentWakeWord() async {
+    setState(() {
+      _isLoading = true;
+    });
+    
+    // Initialize if not already done
+    await _settings.initialize();
+    
+    setState(() {
+      _currentWakeWord = _settings.wakeWord;
+      _wakeWordController.text = _currentWakeWord;
+      _isLoading = false;
+    });
+  }
+  
+  Future<void> _updateWakeWord() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    
+    setState(() {
+      _isLoading = true;
+    });
+    
+    final newWakeWord = _wakeWordController.text.trim();
+    final success = await _settings.updateWakeWord(newWakeWord);
+    
+    setState(() {
+      _isLoading = false;
+    });
+    
+    if (success) {
+      _currentWakeWord = newWakeWord;
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Wake word updated to "$newWakeWord"')),
+        );
+      }
+    } else {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Failed to update wake word')),
+        );
+      }
+    }
+  }
+  
+  Future<void> _resetToDefault() async {
+    setState(() {
+      _isLoading = true;
+    });
+    
+    final success = await _settings.resetToDefault();
+    
+    setState(() {
+      if (success) {
+        _currentWakeWord = _settings.defaultWakeWord;
+        _wakeWordController.text = _currentWakeWord;
+      }
+      _isLoading = false;
+    });
+    
+    if (success && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Wake word reset to "${_settings.defaultWakeWord}"')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Wake Word Settings'),
+      ),
+      body: _isLoading 
+        ? const Center(child: CircularProgressIndicator())
+        : Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Customize your wake word',
+                    style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  const Text(
+                    'The wake word is the keyword that activates voice commands. Say this word followed by your command.',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                  const SizedBox(height: 24),
+                  TextFormField(
+                    controller: _wakeWordController,
+                    decoration: InputDecoration(
+                      labelText: 'Wake Word',
+                      hintText: 'Enter a new wake word',
+                      border: OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: const Icon(Icons.clear),
+                        onPressed: () {
+                          _wakeWordController.clear();
+                        },
+                      ),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Wake word cannot be empty';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: _updateWakeWord,
+                          child: const Text('Update Wake Word'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: _resetToDefault,
+                          child: const Text('Reset to Default'),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text(
+                            'Current Settings',
+                            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(height: 8),
+                          Row(
+                            children: [
+                              const Text('Current Wake Word: '),
+                              Text(
+                                _currentWakeWord,
+                                style: const TextStyle(fontWeight: FontWeight.bold),
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 4),
+                          Row(
+                            children: [
+                              const Text('Default Wake Word: '),
+                              Text(
+                                _settings.defaultWakeWord,
+                                style: const TextStyle(color: Colors.grey),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Example Usage:',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '"$_currentWakeWord, what\'s the weather today?"',
+                    style: const TextStyle(fontStyle: FontStyle.italic),
+                  ),
+                  Text(
+                    '"$_currentWakeWord, set a reminder for tomorrow at 9 AM"',
+                    style: const TextStyle(fontStyle: FontStyle.italic),
+                  ),
+                ],
+              ),
+            ),
+          ),
+    );
+  }
+}

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -107,6 +107,28 @@ class AIService {
     }
   }
   
+  // Process wake word command received from native code
+  Future<void> processWakeWordCommand(String commandText) async {
+    if (_isProcessing) {
+      debugPrint('Already processing a request');
+      return;
+    }
+    
+    _isProcessing = true;
+    try {
+      // Show that we're processing a wake word command
+      await _bluetoothManager.sendText('Processing wake word command...');
+      
+      // Send the command to AGiXT without requiring button press
+      await _sendMessageToAGiXT(commandText);
+    } catch (e) {
+      debugPrint('Error processing wake word command: $e');
+      await _showErrorMessage('Error processing wake word command');
+    } finally {
+      _isProcessing = false;
+    }
+  }
+  
   // Helper methods for displaying status messages
   Future<void> _showListeningIndicator() async {
     await _bluetoothManager.sendText('Listening...');

--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -594,4 +594,20 @@ class BluetoothManager {
     
     debugPrint('Transcription displayed on glasses, AI assistant will process shortly');
   }
+  
+  // Update the wake word in iOS SpeechStreamRecognizer
+  Future<void> updateIOSWakeWord(String wakeWord) async {
+    if (!Platform.isIOS) {
+      return;
+    }
+    
+    try {
+      // Create a method channel specifically for wake word settings
+      const MethodChannel channel = MethodChannel('dev.agixt.agixt/ios_wake_word');
+      await channel.invokeMethod('updateWakeWord', {'wakeWord': wakeWord});
+      debugPrint('iOS wake word updated to: $wakeWord');
+    } catch (e) {
+      debugPrint('Error updating iOS wake word: $e');
+    }
+  }
 }

--- a/lib/utils/wake_word_settings.dart
+++ b/lib/utils/wake_word_settings.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// WakeWordSettings manages the user's custom wake word preferences
+class WakeWordSettings {
+  static final WakeWordSettings singleton = WakeWordSettings._internal();
+  static const String _wakeWordKey = 'wake_word';
+  static const String _defaultWakeWord = 'agent';
+  
+  final MethodChannel _androidSettingsChannel = const MethodChannel('dev.agixt.agixt/wake_word_settings');
+  String _currentWakeWord = _defaultWakeWord;
+  
+  factory WakeWordSettings() {
+    return singleton;
+  }
+  
+  WakeWordSettings._internal();
+  
+  /// Initialize the wake word settings by loading from shared preferences
+  Future<void> initialize() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      _currentWakeWord = prefs.getString(_wakeWordKey) ?? _defaultWakeWord;
+      debugPrint('Loaded wake word: $_currentWakeWord');
+      
+      // Synchronize with platform-specific implementations
+      await _updatePlatformWakeWord(_currentWakeWord);
+    } catch (e) {
+      debugPrint('Error initializing wake word settings: $e');
+    }
+  }
+  
+  /// Get the current wake word
+  String get wakeWord => _currentWakeWord;
+  
+  /// Get the default wake word
+  String get defaultWakeWord => _defaultWakeWord;
+  
+  /// Update the wake word
+  Future<bool> updateWakeWord(String newWakeWord) async {
+    if (newWakeWord.isEmpty) {
+      return false;
+    }
+    
+    try {
+      // Save to shared preferences
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_wakeWordKey, newWakeWord);
+      
+      // Update internal state
+      _currentWakeWord = newWakeWord;
+      
+      // Synchronize with platform-specific implementations
+      await _updatePlatformWakeWord(newWakeWord);
+      
+      debugPrint('Updated wake word to: $newWakeWord');
+      return true;
+    } catch (e) {
+      debugPrint('Error updating wake word: $e');
+      return false;
+    }
+  }
+  
+  /// Reset to default wake word
+  Future<bool> resetToDefault() async {
+    return await updateWakeWord(_defaultWakeWord);
+  }
+  
+  /// Updates the wake word in platform-specific code
+  Future<void> _updatePlatformWakeWord(String wakeWord) async {
+    try {
+      // Update Android native wake word
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        await _androidSettingsChannel.invokeMethod('updateWakeWord', wakeWord);
+      }
+      
+      // Update iOS native wake word
+      if (defaultTargetPlatform == TargetPlatform.iOS) {
+        await const MethodChannel('dev.agixt.agixt/ios_wake_word')
+            .invokeMethod('updateWakeWord', {'wakeWord': wakeWord});
+      }
+    } catch (e) {
+      debugPrint('Error updating platform wake word: $e');
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a wake word detection feature across Android, iOS, and Flutter components. It includes functionality for customizing the wake word, detecting it in speech, and triggering workflows based on detected commands. Key changes are grouped below:

### Android Wake Word Detection and Customization
* Added wake word detection using `SpeechRecognizer` in `BackgroundService` with a default wake word of "agent." Detection triggers a Flutter workflow via `MethodChannel`. [[1]](diffhunk://#diff-2009908214af3edc3576d23d7870724284ff7c954347852762c0910752ffeb0eR13-R35) [[2]](diffhunk://#diff-2009908214af3edc3576d23d7870724284ff7c954347852762c0910752ffeb0eR128-R222)
* Implemented persistence for custom wake words using `SharedPreferences` and a method to update the wake word dynamically from Flutter. [[1]](diffhunk://#diff-2009908214af3edc3576d23d7870724284ff7c954347852762c0910752ffeb0eR46-R59) [[2]](diffhunk://#diff-da7c424773c2af4d81ea0496e38923ba5ef7886c4599ef6946842ac4f07f3276R72-R100)

### iOS Wake Word Detection and Customization
* Integrated wake word detection in `SpeechStreamRecognizer` with a default wake word of "agent." Commands are sent to Flutter via `BluetoothManager`.
* Added a method to update the wake word dynamically and persisted it using `UserDefaults`. [[1]](diffhunk://#diff-59f40e9b0a3cbe1392f027d0715c90ea0e3571c618ec9c09cfd1e71392aac3faR40-R51) [[2]](diffhunk://#diff-59f40e9b0a3cbe1392f027d0715c90ea0e3571c618ec9c09cfd1e71392aac3faR70-R76)

### Flutter Integration
* Introduced a `MethodChannel` for handling wake word detection and processing voice commands using `AIService`. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R26-R28) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R372-R390)
* Added a new `WakeWordSettingsScreen` for customizing the wake word, accessible from the settings menu. [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R216) [[2]](diffhunk://#diff-01804aeb7da5fa05de3787c3aa6f9ba4af679ece6a4e7a28a990ad6520fb33faR90-R106)