### PR TITLE
Improve main screen

### DIFF
--- a/lib/screens/auth/profile_screen.dart
+++ b/lib/screens/auth/profile_screen.dart
@@ -178,21 +178,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   ] else
                     const SizedBox(height: 40),
 
-                  // Go to AGiXT button
-                  ElevatedButton.icon(
-                    onPressed: _openAGiXTWeb,
-                    icon: const Icon(Icons.open_in_browser),
-                    label: Text('Go to $appName'),
-                    style: ElevatedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(
-                        vertical: 16,
-                        horizontal: 24,
-                      ),
-                      minimumSize: const Size(double.infinity, 0),
-                    ),
-                  ),
-
-                  const SizedBox(height: 16),
+                  const SizedBox(height: 20),
 
                   // Logout button
                   OutlinedButton.icon(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -10,6 +10,7 @@ import 'package:agixt/utils/ui_perfs.dart';
 import 'package:agixt/widgets/current_agixt.dart';
 import 'package:agixt/widgets/gravatar_image.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../services/bluetooth_manager.dart';
 
 class HomePage extends StatefulWidget {
@@ -100,8 +101,19 @@ class _HomePageState extends State<HomePage> {
     await aiService.handleSideButtonPress();
   }
 
+  Future<void> _openAGiXTWeb() async {
+    final url = await AuthService.getWebUrlWithToken();
+    final uri = Uri.parse(url);
+
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final appName = AuthService.appName;
+    
     return Scaffold(
       appBar: AppBar(
         title: const Text('AGiXT'),
@@ -150,6 +162,7 @@ class _HomePageState extends State<HomePage> {
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
+          // Current AGiXT info
           CurrentAGiXT(),
 
           // AI Assistant Card
@@ -192,7 +205,47 @@ class _HomePageState extends State<HomePage> {
             ),
           ),
 
-          // Other menu items
+          // Go to AGiXT Web button
+          Card(
+            margin: const EdgeInsets.symmetric(vertical: 10.0),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Icon(Icons.open_in_browser, color: Theme.of(context).primaryColor),
+                      const SizedBox(width: 10),
+                      const Text(
+                        'AGiXT Web Interface',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  const Text(
+                    'Access the full AGiXT web interface in your browser.',
+                    style: TextStyle(fontSize: 14),
+                  ),
+                  const SizedBox(height: 15),
+                  ElevatedButton.icon(
+                    onPressed: _openAGiXTWeb,
+                    icon: const Icon(Icons.open_in_browser),
+                    label: Text('Go to $appName'),
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size(double.infinity, 44),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // Daily items
           ListTile(
             title: Row(
               children: [
@@ -214,6 +267,8 @@ class _HomePageState extends State<HomePage> {
               );
             },
           ),
+          
+          // Stop items
           ListTile(
             title: Row(
               children: [
@@ -235,6 +290,8 @@ class _HomePageState extends State<HomePage> {
               );
             },
           ),
+          
+          // Checklists
           ListTile(
             title: Row(
               children: [
@@ -253,27 +310,6 @@ class _HomePageState extends State<HomePage> {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => AGiXTChecklistPage()),
-              );
-            },
-          ),
-          ListTile(
-            title: Row(
-              children: [
-                _ui.trainNerdMode
-                    ? Image(
-                        image: AssetImage('assets/icons/groen.png'),
-                        height: 20,
-                      )
-                    : Icon(Icons.calendar_today),
-                SizedBox(width: 10),
-                Text('Calendar Integration'),
-              ],
-            ),
-            trailing: Icon(Icons.chevron_right),
-            onTap: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => CalendarsPage()),
               );
             },
           ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:agixt/screens/settings/notifications_screen.dart';
 import 'package:agixt/widgets/gravatar_image.dart';
 import 'package:agixt/models/agixt/auth/auth.dart';
 import 'package:agixt/screens/auth/profile_screen.dart';
+import 'package:agixt/screens/calendars_screen.dart';
 import 'package:flutter/material.dart';
 
 class SettingsPage extends StatefulWidget {
@@ -126,6 +127,22 @@ class _SettingsPageState extends State<SettingsPage> {
                 context,
                 MaterialPageRoute(
                     builder: (context) => DashboardSettingsPage()),
+              );
+            },
+          ),
+          ListTile(
+            title: Row(
+              children: [
+                Icon(Icons.calendar_today),
+                SizedBox(width: 10),
+                Text('Calendar Integration'),
+              ],
+            ),
+            trailing: Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => CalendarsPage()),
               );
             },
           ),


### PR DESCRIPTION
This pull request makes several updates to the `ProfileScreen`, `HomePage`, and `SettingsPage` components, focusing on UI improvements, feature reorganization, and code reuse. The most notable changes include moving the "Go to AGiXT Web" button from the `ProfileScreen` to the `HomePage` with an enhanced design, adding a new "Calendar Integration" option to the `SettingsPage`, and removing redundant or unused UI elements.

### UI Updates and Feature Reorganization:

* **"Go to AGiXT Web" Button Relocation and Enhancement**:
  - Removed the "Go to AGiXT" button from the `ProfileScreen` (`lib/screens/auth/profile_screen.dart`) to streamline its UI.
  - Added the "Go to AGiXT Web" button to the `HomePage` with a new card-based design, including a description and improved styling. The button uses the `_openAGiXTWeb` method for functionality. [[1]](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddL195-R248) [[2]](diffhunk://#diff-935e56a557f0ab902a679f47de66345d9f47058bccb96f870e6383d19e2c86ddR104-R116)

* **New "Calendar Integration" Option**:
  - Added a "Calendar Integration" option to the `SettingsPage`, allowing users to navigate to the `CalendarsPage`. This includes importing the relevant screen and defining a new `ListTile`. [[1]](diffhunk://#diff-01804aeb7da5fa05de3787c3aa6f9ba4af679ece6a4e7a28a990ad6520fb33faR8) [[2]](diffhunk://#diff-01804aeb7da5fa05de3787c3aa6f9ba4af679ece6a4e7a28a990ad6520fb33faR133-R148)

### Code Cleanup and Reorganization:

* **Code Removal**:
  - Removed the old "Calendar Integration" `ListTile` from the `HomePage`, as it has been moved to the `SettingsPage` for better organization.

* **Code Reuse**:
  - Introduced a reusable `_openAGiXTWeb` method in the `HomePage` to handle launching the AGiXT web interface.

These changes improve the user experience by reorganizing features into more appropriate locations and enhancing the design of key UI elements.