### PR TITLE
Handle external links and update permissions

### DIFF
--- a/lib/services/bluetooth_manager.dart
+++ b/lib/services/bluetooth_manager.dart
@@ -174,6 +174,7 @@ class BluetoothManager {
         Permission.bluetoothScan,
         Permission.bluetoothConnect,
         Permission.location,
+        Permission.ignoreBatteryOptimizations,
       ].request();
 
       // Don't throw exceptions for denied permissions, just log them

--- a/lib/services/permission_manager.dart
+++ b/lib/services/permission_manager.dart
@@ -7,6 +7,7 @@ class PermissionManager {
     Permission.bluetoothScan,
     Permission.bluetoothConnect,
     Permission.location,
+    Permission.ignoreBatteryOptimizations,
     Permission.notification,
   ];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   android_package_manager: ^0.7.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  build_runner: ^2.4.14
+  build_runner: 2.4.13
   hive_generator: ^2.0.1
   shared_preferences: ^2.3.4
   http: ^1.2.2


### PR DESCRIPTION
External links in the WebView are now opened in the browser using url_launcher. Added Permission.ignoreBatteryOptimizations to permission requests in BluetoothManager and PermissionManager. Downgraded build_runner dependency in pubspec.yaml.